### PR TITLE
add hasura-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Blazing fast, instant realtime GraphQL APIs on Postgres with fine grained access
 - [Hasura Auto Tracker](https://github.com/axis-tech/hasura-auto-tracker) - Configure Hasura to track tables, views and functions using configuration driven process.
 - [Hasura Squasher](https://github.com/domasx2/hasura-squasher) - CLI Utlity to squash Hasura Migrations
 - [Hasura Segment Source](https://github.com/aaronhayes/hasura-segment-source) - The easiest way to connect hasura and segment!
+- [hasura-cli](https://github.com/jjangga0214/hasura-cli) - Hasura CLI as an npm package
 
 ## Tutorials
 


### PR DESCRIPTION
`hasura-cli` is an npm package.
If you want a version-fixed, project-dedicated(not global) cli written in package.json, it's a way to go. This will ensure every colleague have the same version, make project-specific scripts stable.

* [repository](https://github.com/jjangga0214/hasura-cli)
* [npm](https://www.npmjs.com/package/hasura-cli) 
* https://github.com/hasura/graphql-engine/pull/3095: A PR to official docs
* https://github.com/hasura/graphql-engine/issues/2720: An issue this package resolves, and working screenrecord.