### PR TITLE
fix typo near Hasura Starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ![Awesome Hasura](asset/awesome-hasura.svg)
 
->  A curated list of awesome things related to the [hasura](https://hasura.io) ecosystem.
-
+> A curated list of awesome things related to the [hasura](https://hasura.io) ecosystem.
 
 ## Contents
 
@@ -11,7 +10,6 @@
 - [Templates and Examples](#templates-and-examples)
 - [Managed Services](#managed-services)
 - [Blogs](#blogs)
-
 
 ## Hasura
 
@@ -23,10 +21,9 @@ Blazing fast, instant realtime GraphQL APIs on Postgres with fine grained access
 - [Discord](https://discord.gg/hasura)
 - [Blog](https://blog.hasura.io/)
 
-
 ## Tools and Extensions
 
-- [Hasura Backend Plus](https://github.com/elitan/hasura-backend-plus) - Auth + Storage for Hasura. 
+- [Hasura Backend Plus](https://github.com/elitan/hasura-backend-plus) - Auth + Storage for Hasura.
 - [Hasura JWT Auth](https://github.com/sander-io/hasura-jwt-auth) - Hasura JWT auth using PostgreSQL
 - [Hasura Auto Tracker](https://github.com/axis-tech/hasura-auto-tracker) - Configure Hasura to track tables, views and functions using configuration driven process.
 - [Hasura Squasher](https://github.com/domasx2/hasura-squasher) - CLI Utlity to squash Hasura Migrations
@@ -39,16 +36,17 @@ Blazing fast, instant realtime GraphQL APIs on Postgres with fine grained access
 - [Production Checklist](https://docs.hasura.io/1.0/graphql/manual/deployment/production-checklist.html)
 
 ## Templates and Examples
+
 - [Hasura Community](https://github.com/hasura/graphql-engine/tree/master/community) - Community Contributed boilerplates, example apps, and todos.
 - [NextJS - Auth0 - Hasura](https://github.com/vgrafe/nextjs-auth0-hasura) - Template project with NextJs, Auth0, Hasura and Apollo.
 - [Rust Hasura](https://github.com/ronanyeah/rust-hasura) - Boilerplate/example of using Rust as a Remote Schema. It features login, signup, JWT, hashed passwords and typesafe requests.
-- [Hasura Starter](https://github.com/jjangga0214/hasura-starter) - A bolerplate, cheatsheet, and guide for beginners.
+- [Hasura Starter](https://github.com/jjangga0214/hasura-starter) - A bolierplate, cheatsheet, and guide for beginners.
 
 ## Managed Services
+
 - [nHost](https://nhost.io/) - Hasura as a Service!
 
 ## Blogs
 
- - [Migrating from Firebase to Hasura](https://medium.com/@clapie.florent/how-i-scale-firebase-by-migrating-to-graphql-and-speed-up-my-development-by-10x-200b4a3068a0?sk=cf4a748bfa93d061ad84fd194d5e87bb)
- - [Resetting Hasura Migrations](https://blog.hasura.io/resetting-hasura-migrations/)
-
+- [Migrating from Firebase to Hasura](https://medium.com/@clapie.florent/how-i-scale-firebase-by-migrating-to-graphql-and-speed-up-my-development-by-10x-200b4a3068a0?sk=cf4a748bfa93d061ad84fd194d5e87bb)
+- [Resetting Hasura Migrations](https://blog.hasura.io/resetting-hasura-migrations/)


### PR DESCRIPTION
This PR fixes `bolerplate` to `boilerplate`.

Also, readme is formatted by [vscode-markdownlint](https://github.com/DavidAnson/vscode-markdownlint), using [markdownlint](https://github.com/DavidAnson/markdownlint) as linter.

*I know linting is a subject of preference, so I hope you like it. If not, let me know.*