### PR TITLE
Includes xsura CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Blazing fast, instant realtime GraphQL APIs on Postgres with fine grained access
 - [hasura-metadata-patcher](https://github.com/puzl-ee/hasura-metadata-patcher) - CLI tool to patch Hasura `metadata.json` file with needed objects or with another Hasura metadata file. You can use it to deploy complex CI/CD flows for applications, which are using Hasura on a backend.
 - [Hasura Helm chart](https://github.com/platyplus/platyplus/tree/master/charts/hasura) - Deploy Hasura on a [Kubernetes](https://kubernetes.io/) cluster with [Helm](https://helm.sh/).
 - [hasura-supertokens](https://github.com/offscriptio/hasura-supertokens) - A webhook implementation to connect Hasura with [Supertokens](https://supertokens.io/) for role-based authentication.
+- [xsura](https://github.com/joaom182/xsura) Migrate data smoothly between two Hasura servers
 
 ## Tutorials
 


### PR DESCRIPTION
# About
This is a tool to migrate data between two Hasura instances through the GraphQL endpoints

# The problem
If you are trying to migrate data from an Hasura environment to another that runs in a free tier, you will face issues with the permission level of your Postgres credentials.

For example, if you try to run the COPY command to import the data from a CSV file using the Postgres CLI `psql`, you will receive this error message:

```
ERROR: must be a superuser or a member of the pg_read_server_files role to COPY from a file
```

This error occurs because a free tier instance of Hasura runs in a shared server, which means that the database server, has many other users running their databases, and it's reasonable to you not have a superuser or a different grant on the database server due to security reasons.

# Solution
Fetch the data using the GraphQL introspection query to discover the properties/fields of each table/field on GraphQL, and dynamically insert it to the tables using the Hasura insert mutation convention `insert_<field_name>`

[xsura](https://github.com/joaom182/xsura)